### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ This plugin adds a model called `markov`. You can execute it like this:
 llm -m markov "The quick brown fox jumps over the lazy dog"
 ```
 
-My default it will produce 100 words. You can control the number of words with the `-o number` option:
+My default it will produce 100 words. You can control the number of words with the `-o length number` option:
 
 ```bash
-llm -m markov -o 20 "The quick brown fox jumps over the lazy dog"
+llm -m markov -o length 20 "The quick brown fox jumps over the lazy dog"
 ```
 A delay of 0.02s is simulated between each token. You can modify this using the `-o delay` option - to `0` to disable it, or some other floating point number of seconds to customize it:
 


### PR DESCRIPTION
Fix README typo for the `length` option.